### PR TITLE
Fix decade book titles sometimes not displaying correctly.

### DIFF
--- a/app/gridNavigation/chronology.tsx
+++ b/app/gridNavigation/chronology.tsx
@@ -186,7 +186,7 @@ type BookChronologyEntryProps = {
 };
 function BookChronologyEntry(props: BookChronologyEntryProps) {
   const TOTAL_TITLE_CHARS_TO_SHOW = 16;
-  const TOTAL_TITLE_CHARS_TO_SHOW_IN_DECADE = 14;
+  const TOTAL_TITLE_CHARS_TO_SHOW_IN_DECADE = 13;
   const [maxChars, setMaxChars] = useState<number>(0);
 
   useEffect(() => {


### PR DESCRIPTION
Some book titles cannot fit on a single line, causing layout issues with titles above or below, particularly within decade blocks ([image](https://github.com/dimstefanakis/myshelf/assets/45954373/74fb8034-1bcd-4dac-bf1f-43480ff65e9c)). To address this, I've reduced the maximum allowed characters for titles within decade blocks ([image](https://github.com/dimstefanakis/myshelf/assets/45954373/99ebfbcd-92fc-4fb8-aae8-6dd2f5c01c86)).

